### PR TITLE
Add a space between the title of page and Username

### DIFF
--- a/MVCForum.Website/Views/Members/Report.cshtml
+++ b/MVCForum.Website/Views/Members/Report.cshtml
@@ -2,7 +2,7 @@
 
 @{
     Layout = "~/Views/Shared/_LayoutFullWidth.cshtml";
-    ViewBag.Title = string.Concat(Html.LanguageString("Report.Report"), Model.Username);
+    ViewBag.Title = string.Concat(Html.LanguageString("Report.Report"), " ", Model.Username);
 }
 
 <div class="row">


### PR DESCRIPTION
The concat function was not including a space between the word for Report.Report and the username.