### PR TITLE
Improve guidance for visitors by showing create topic button. This leads visitors who want to post a message to registration.

### DIFF
--- a/MVCForum.Website/Views/Shared/_LayoutRightSideBar.cshtml
+++ b/MVCForum.Website/Views/Shared/_LayoutRightSideBar.cshtml
@@ -17,10 +17,7 @@
     </div>
     <div class="col-md-3 sidelayoutsection">
         <div class="main-side-box clearfix">
-            @if (User.Identity.IsAuthenticated)
-            {
-                @Html.Action("CreateTopicButton", "Topic")
-            }
+            @Html.Action("CreateTopicButton", "Topic")
             @RenderSection("side", false)
         </div>
     </div>

--- a/MVCForum.Website/Views/Topic/CreateTopicButton.cshtml
+++ b/MVCForum.Website/Views/Topic/CreateTopicButton.cshtml
@@ -1,9 +1,6 @@
 ﻿@model MVCForum.Website.ViewModels.CreateTopicButtonViewModel
-@if (Model.LoggedOnUser != null && Model.LoggedOnUser.DisablePosting != true && Model.UserCanPostTopics)
-{
-    <div class="createtopicbutton">
-        <a href="@Url.Action("Create", "Topic")" class="btn-mvc-green btn-mvc-large btn-mvc-fullwidth">
-            @Html.LanguageString("Layout.CreateButton")
-        </a>
-    </div>
-}
+<div class="createtopicbutton">
+    <a href="@Url.Action("Create", "Topic")" class="btn-mvc-green btn-mvc-large btn-mvc-fullwidth">
+        @Html.LanguageString("Layout.CreateButton")
+    </a>
+</div>


### PR DESCRIPTION
This change aims to solve the problem that a visitor cannot see how to post a message. For someone not familiar with the software it is not obvious that clicking on "Register" is required to post a message.